### PR TITLE
Add PLEP index (with reserved numbers) and template

### DIFF
--- a/PLEP-0000.md
+++ b/PLEP-0000.md
@@ -1,0 +1,41 @@
+# PLEP-0000 - Index of PlasmaPy Enhancement Proposals (PLEPs)
+
+| PLEP              | 0                        |
+|-------------------|--------------------------|
+| title             | PLEP Index               |
+| author(s)         | Nick Murphy              |
+| contact email     | namurphy@cfa.harvard.edu |
+| date created      | 2017-09-28               |
+| date last revised | 2017-09-28               |
+| type              | informational            |
+
+This PLEP is an index of all PlasmaPy Enhancement Proposals, known as
+PLEPs (to avoid confusion with Python Enhancement Proposals, or PEPs).
+
+## PLEPs about PLEPs
+
+| number | title | author(s) | type |
+|--------|-------|-----------|------|
+| 0 | [Index of PLEPs](./PLEP-0000.md) | Nick Murphy | informational |
+
+## Accepted PLEPs
+
+| number | title | author(s) | type |
+|--------|-------|-----------|------|
+|        |       |           |      |
+
+## Declined PLEPs
+
+| number | title | author(s) | type |
+|--------|-------|-----------|------|
+|        |       |           |      |
+
+## PLEPs in preparation or under consideration
+
+| number | title | author(s) | type |
+|--------|-------|-----------|------|
+| 1 | [Purpose and Guidelines of PLEPs](./PLEP-0001.md)  | | informational |
+| 2 | [PlasmaPy Organizational Structure](./PLEP-0002.md)| | process       |
+| 3 | [Coordinating Committee Members](./PLEP-0003.md)   | | informational |
+| 4 | [PlasmaPy License](./PLEP-0004)                    | | process       |
+| 5 | [Versioning and Releases](./PLEP-0005.md)          | | process       |

--- a/PLEP-0000.md
+++ b/PLEP-0000.md
@@ -34,8 +34,14 @@ PLEPs (to avoid confusion with Python Enhancement Proposals, or PEPs).
 
 | number | title | author(s) | type |
 |--------|-------|-----------|------|
+| 4 | [PlasmaPy License](./PLEP-0004) | | process       |
+
+## Reserved PLEPs
+
+| number | title | author(s) | type |
+|--------|-------|-----------|------|
 | 1 | [Purpose and Guidelines of PLEPs](./PLEP-0001.md)  | | informational |
 | 2 | [PlasmaPy Organizational Structure](./PLEP-0002.md)| | process       |
 | 3 | [Coordinating Committee Members](./PLEP-0003.md)   | | informational |
-| 4 | [PlasmaPy License](./PLEP-0004)                    | | process       |
 | 5 | [Versioning and Releases](./PLEP-0005.md)          | | process       |
+| 6 | [Data Structures](./PLEP-0006.md)                  | | standard      |

--- a/PLEP-template.md
+++ b/PLEP-template.md
@@ -1,0 +1,53 @@
+# PLEP-*number* -- *PLEP title*
+
+| PLEP          | number                       |
+|---------------|------------------------------|
+| title         | PLEP Title |
+| author(s)     |  |
+| contact email | me@myemail.org |
+| date created | YYYY-MM-DD |
+| date last revised | YYYY-MM-DD |
+| type          | process, standard, informational |
+| status        | discussion, accepted, declined |
+
+# Abstract
+
+*Briefly describe this PLEP in a paragraph, including a statement of
+the problem that this PLEP addresses.*
+
+# Detailed Description
+
+*Provide an extended description of the problem and the proposed
+changes, including usage examples when needed.*
+
+# Implementation
+
+*Describe the steps necessary to implement this PLEP, if necessary.*
+
+# Issues, Pull Requests, and Branches
+
+*Provide repository links related to this PLEP, and include
+descriptions.*
+
+# Backward Compatibility
+
+*State whether or not this PLEP will maintain backward compatibility
+and describe the proposed changes, if necessary.  Backward
+compatibility does not need to be maintained between development
+releases (with a major version number of zero).  Starting with version
+1.0, backward incompatible changes can only happen when the major
+version number is incremented.*
+
+# Alternatives
+
+*Summarize alternative possibilities to address (or not address) the
+problem described in this PLEP, if necessary.*
+
+# Decision Rationale
+
+*Summarize the discussion on this PLEP and describe the reasoning
+behind the decision, if necessary.*
+
+*Not all PLEPs require all of these sections, and occasionally
+additional sections may be necessary.  Emphasized text should be
+deleted.*


### PR DESCRIPTION
This pull request adds PLEP 0 as an index of PLEPs.

This also reserves the following PLEP numbers for PlasmaPy organizational stuff:

number | title | author(s) | type
-- | -- | -- | --
1 | Purpose and Guidelines of PLEPs |   | informational
2 | PlasmaPy Organizational Structure |   | process
3 | Coordinating Committee Members |   | informational
4 | PlasmaPy License |   | process
5 | Versioning and Releases |   | process

 - We undoubtedly need PLEP 1 which will include the process for how PLEPs are created and decided upon.
- We may need an organizational structure PLEP, which I tentatively put as PLEP 2.  An alternative would be to keep much of this information in the vision statement.  
- Following SunPy's practices, we can have PLEP 3 on members of the coordinating committee.  Otherwise we can put this on our website when we get one, or elsewhere.
- I was hoping to write a PLEP related to the licensing pull request that I made in https://github.com/PlasmaPy/PlasmaPy/pull/114.  This could be PLEP 4.
- We probably should also specify our versioning and release procedures, perhaps in PLEP 5.  This is inspired by: https://github.com/sunpy/sunpy-SEP/pull/30

Do the index and template look good?  Does it make sense to reserve these PLEP numbers for these items?  And is there a better acronym than PLEP, given that PEP is kind of already in wide use?